### PR TITLE
added react-error-overlay to propery display react errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,15 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "react-error-overlay": "6.0.9",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0"
+  },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
   }
-}
+  }


### PR DESCRIPTION
There is an iframe that blocks the pointer events on the page, thus preventing clicking of any links. This iframe is supposed to render the error log from react during development, and in the current branch, the error is due to a prop type violation. However, that error doesn't get rendered, instead an invisible iframe is rendered on top of the whole page.

This update adds react-error-overlay as a dev dependency and now properly renders the react error.