### PR TITLE
fix: bundle lazy-loaded route components so deep links work

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -26,7 +26,7 @@ function MainApp() {
             <Route exact path="/" element={<Home />} />
             {data
               && data.sections.map((route) => {
-                const SectionComponent = React.lazy(() => import('./components/' + route.component));
+                const SectionComponent = React.lazy(() => import(`./components/${route.component}.jsx`));
                 return (
                   <Route
                     key={route.headerTitle}


### PR DESCRIPTION
## Problem
Opening any non-home route directly (deep link or refresh) — e.g. `/about`, `/projects` — failed with `error loading dynamically imported module … /assets/components/About` (disallowed MIME type). It only worked when navigating client-side from the home page.

## Cause
In `src/MainApp.jsx` the route components were lazy-loaded with a **string-concatenated** dynamic import:

```js
React.lazy(() => import('./components/' + route.component))
```

Vite cannot statically analyze this, so it emits **no per-route chunks** — at runtime the app requests a non-existent `/assets/components/About`, which the SPA fallback serves as `index.html` (`text/plain`).

## Fix
Use an analyzable template literal with an explicit extension so Vite bundles a hashed chunk per route:

```js
React.lazy(() => import(`./components/${route.component}.jsx`))
```

## Verification
`npm run build` now emits `assets/About-*.js`, `Projects-*.js`, … chunks (previously a single bundle). Verified locally with `vite preview` — deep-linking `/about`, `/projects`, `/skills`, `/experience`, `/education` works.